### PR TITLE
feat: Add support for 'ytdlp_options' in yaml configuration

### DIFF
--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -65,16 +65,16 @@ series:
       # remove_quotes: True # Replaces Punctuation Apostrophes by Typewriter Apostrophes. Used by apply_default_format
       # make_ponctuation_optional: True # Replaces ponctuations by optional ponctuations. Used by apply_default_format
 
-      # The options to be passed to yt-dlp. See more on https://github.com/yt-dlp/yt-dlp/blob/db50f19d76c6870a5a13d0cab9287d684fd7449a/yt_dlp/YoutubeDL.py#L176
-      ytdlp:
-        username: "yourusername"
-        password: "yourpassword"
-        extractor_args: 
-          crunchyrollbeta:
-            hardsub: 
-              - pt-BR
-        impersonate: ""
-        http_headers:
-          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
-        # Used for merging the video and audio files. Only applicable if debugging the code. The image already includes the ffmpeg binary
-        ffmpeg_location: "C:\\ProgramData\\chocolatey\\lib\\ffmpeg\\tools\\ffmpeg\\bin" 
+    # The options to be passed to yt-dlp. See more on https://github.com/yt-dlp/yt-dlp/blob/db50f19d76c6870a5a13d0cab9287d684fd7449a/yt_dlp/YoutubeDL.py#L176
+    ytdlp:
+      username: "yourusername"
+      password: "yourpassword"
+      extractor_args: 
+        crunchyrollbeta:
+          hardsub: 
+            - pt-BR
+      impersonate: ""
+      http_headers:
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+      # Used for merging the video and audio files. Only applicable if debugging the code. The image already includes the ffmpeg binary
+      ffmpeg_location: "C:\\ProgramData\\chocolatey\\lib\\ffmpeg\\tools\\ffmpeg\\bin" 

--- a/app/config.yml.template
+++ b/app/config.yml.template
@@ -43,7 +43,7 @@ series:
   # Crunchyroll series
   - title: Gintama
     url: https://www.crunchyroll.com/series/GYQ4MKDZ6
-    cookies_file: crunchyroll_cookies.txt # located in the same config folder
+    # cookies_file: crunchyroll_cookies.txt # located in the same config folder
     playlistreverse: False
     # The formats to be applied to the title comming from Sonarr to, then, match against the title comming frm yt-dlp
     title_format:
@@ -64,3 +64,17 @@ series:
       # Other possible options:
       # remove_quotes: True # Replaces Punctuation Apostrophes by Typewriter Apostrophes. Used by apply_default_format
       # make_ponctuation_optional: True # Replaces ponctuations by optional ponctuations. Used by apply_default_format
+
+      # The options to be passed to yt-dlp. See more on https://github.com/yt-dlp/yt-dlp/blob/db50f19d76c6870a5a13d0cab9287d684fd7449a/yt_dlp/YoutubeDL.py#L176
+      ytdlp:
+        username: "yourusername"
+        password: "yourpassword"
+        extractor_args: 
+          crunchyrollbeta:
+            hardsub: 
+              - pt-BR
+        impersonate: ""
+        http_headers:
+          "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
+        # Used for merging the video and audio files. Only applicable if debugging the code. The image already includes the ffmpeg binary
+        ffmpeg_location: "C:\\ProgramData\\chocolatey\\lib\\ffmpeg\\tools\\ffmpeg\\bin" 

--- a/app/sonarr_youtubedl.py
+++ b/app/sonarr_youtubedl.py
@@ -318,14 +318,15 @@ class SonarrYTDL(object):
         else:
             return ytdlopts
 
-    def ytdl_eps_search_opts(self, regextitle, playlistreverse, cookies=None):
-        ytdlopts = {
+    def ytdl_eps_search_opts(self, regextitle, playlistreverse, ytdlp_options, cookies=None):
+        ytdlopts = ytdlp_options
+        ytdlopts.update({
             'ignoreerrors': True,
             'playlistreverse': playlistreverse,
             'matchtitle': regextitle,
             'quiet': True,
+        })
 
-        }
         if self.debug is True:
             ytdlopts.update({
                 'quiet': False,
@@ -375,11 +376,17 @@ class SonarrYTDL(object):
                         url = ser['url']
                         if 'cookies_file' in ser:
                             cookies = ser['cookies_file']
-                        ydleps = self.ytdl_eps_search_opts(upperescape(eps['title'], ser['title_format']), ser['playlistreverse'], cookies)
+                        ydleps = self.ytdl_eps_search_opts(upperescape(eps['title'], ser['title_format']), ser['playlistreverse'], ser['ytdlp_options'], cookies)
                         found, dlurl = self.ytsearch(ydleps, url)
                         if found:
                             logger.info("    {}: Found - {}:".format(e + 1, eps['title']))
-                            ytdl_format_options = {
+
+                            ytdl_format_options = {}
+
+                            if 'ytdlp_options' in ser:
+                                ytdl_format_options = ser['ytdlp_options']
+
+                            ytdl_format_options.update({
                                 'format': self.ytdl_format,
                                 'quiet': True,
                                 'merge-output-format': 'mp4',
@@ -392,7 +399,7 @@ class SonarrYTDL(object):
                                 ),
                                 'progress_hooks': [ytdl_hooks],
                                 'noplaylist': True,
-                            }
+                            })
                             ytdl_format_options = self.appendcookie(ytdl_format_options, cookies)
                             if 'format' in ser:
                                 ytdl_format_options = self.customformat(ytdl_format_options, ser['format'])


### PR DESCRIPTION
Closes #6 

Now we can add the following `ytdlp` options to the config file:

```yaml
series:
  # Standard channel to check
  - title: Gintama
    url: https://www.crunchyroll.com/series/GYQ4MKDZ6
    # cookies_file: crunchyroll_cookies.txt # located in the same config folder
    playlistreverse: False
    # The options to be passed to yt-dlp. See more on https://github.com/yt-dlp/yt-dlp/blob/db50f19d76c6870a5a13d0cab9287d684fd7449a/yt_dlp/YoutubeDL.py#L176
    ytdlp:
      username: "yourusername"
      password: "yourpassword"
      extractor_args: 
        crunchyrollbeta:
          hardsub: 
            - pt-BR
      impersonate: ""
      http_headers:
        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/125.0.0.0 Safari/537.36"
      # Used for merging the video and audio files. Only applicable if debugging the code. The image already includes the ffmpeg binary
      ffmpeg_location: "C:\\ProgramData\\chocolatey\\lib\\ffmpeg\\tools\\ffmpeg\\bin" 
```

After the changes on the config.yaml, the episode is downloaded and merged correctly
![image](https://github.com/g-nogueira/sonarr_ytdlp/assets/27465604/c7ead072-6fa0-4188-a235-a0245a40582a)
![image](https://github.com/g-nogueira/sonarr_ytdlp/assets/27465604/ff90ac8c-097c-4ac3-a171-7e096db8df9e)
